### PR TITLE
Small bug fixes

### DIFF
--- a/src/atoms/Section/Section.tsx
+++ b/src/atoms/Section/Section.tsx
@@ -24,6 +24,7 @@ export const ExtendedSectionLeft = ({
   return (
     <Section
       bg={backgroundColor}
+      position="relative"
       {...restProps}
       _after={{
         content: '""',

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -9,7 +9,7 @@ The Hero component is used to establish visually appealing sections on webpages.
 
 ## General Hero
 
-These can be used on all pages excluding a HomePage. Properties of this component include: `backgroundColour`, `testColour`, `heading`, `pageTitle` and a `description`
+These can be used on all pages excluding a HomePage. Properties of this component include: `backgroundColour`, `textColour`, `heading`, `pageTitle` and a `subHeading`
 
 <Canvas>
   <Story of={HeroStories.Default} />

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -17,7 +17,7 @@ export const Default: Story = {
     backgroundColour: 'brand.legacyBlue',
     textColour: 'brand.white.500',
     heading: 'Main Heading',
-    children: 'Content',
+    subHeading: 'Content',
   },
   render: (args) => <Hero {...args} />,
 }

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -3,12 +3,11 @@ import { ExtendedSectionLeft } from '../../atoms/Section/Section'
 import { Box, BoxProps, Heading, Text, Flex } from '@chakra-ui/react'
 
 export interface HeroProps extends BoxProps {
-  /** Main text heading for the hero */
-
   heading: string
   pageTitle?: string
   backgroundColour?: string
   textColour?: string
+  subHeading?: string
 }
 
 const Hero = ({
@@ -16,7 +15,7 @@ const Hero = ({
   backgroundColour,
   textColour,
   heading,
-  children,
+  subHeading,
 }: HeroProps) => {
   return (
     <ExtendedSectionLeft
@@ -82,7 +81,7 @@ const Hero = ({
           maxWidth="23ch"
           pt="2rem"
         >
-          {children}
+          {subHeading}
         </Text>
       </Flex>
     </ExtendedSectionLeft>


### PR DESCRIPTION
@hannahouazzane some interesting bugs. Eslint is being particular about the use of children as a prop, it turns out it is a protected prop that refers to something in particular, I've renamed it so something else. Also, to make the absolute `after` work on the homepage I've had to make the section `relative`.