### PR TITLE
fix: hero svg not being imported

### DIFF
--- a/src/components/Hero/HomepageHero/HomepageHero.stories.tsx
+++ b/src/components/Hero/HomepageHero/HomepageHero.stories.tsx
@@ -18,7 +18,8 @@ export const Default: Story = {
     introduction:
       'We champion the work of Law Centres across the UK, support the services they provide, and campaign together on a national scale for equal access to justice for everyone.',
     callToAction: 'Join the fight for a fairer society',
-    image: 'homepage-hero-image.png',
+    heroImage: 'homepage-hero-image.png',
+    headingBackground: 'heading-background.svg',
   },
   render: (args) => <HomepageHero {...args} />,
 }

--- a/src/components/Hero/HomepageHero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero/HomepageHero.tsx
@@ -9,8 +9,6 @@ import {
   BoxProps,
 } from '@chakra-ui/react'
 
-import headingBackground from '../../../assets/heading-background.svg'
-
 import { IconArrowRight } from '../../../atoms/Icons/Icons'
 
 export interface HeroProps extends BoxProps {
@@ -18,7 +16,8 @@ export interface HeroProps extends BoxProps {
   subHeading: string
   introduction: string
   callToAction: string
-  image: any
+  heroImage: string
+  headingBackground: string
 }
 
 const Hero = ({
@@ -26,7 +25,8 @@ const Hero = ({
   heading,
   subHeading,
   callToAction,
-  image,
+  headingBackground,
+  heroImage,
 }: HeroProps) => {
   return (
     <Flex direction="column" width="100%" as="section">
@@ -52,7 +52,7 @@ const Hero = ({
             position="absolute"
             height="125%"
             top="-15%"
-            src={image}
+            src={heroImage}
           />
         </Flex>
         <Flex


### PR DESCRIPTION
Similar issue to the HomepageHero image not being imported when used as an npm package. Need to make the heading background a required prop with an image passed in.