### PR TITLE
fix: name of homepage hero

### DIFF
--- a/src/components/Hero/HomepageHero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero/HomepageHero.tsx
@@ -21,7 +21,7 @@ export interface HeroProps extends BoxProps {
   headingBackground: string
 }
 
-const Hero = ({
+const HomepageHero = ({
   introduction,
   heading,
   subHeading,
@@ -123,4 +123,4 @@ const Hero = ({
   )
 }
 
-export default Hero
+export default HomepageHero


### PR DESCRIPTION
Realised I hadn't named this Hero and it should have a unique name. 