### PR TITLE
fix: card height so they fill grids

### DIFF
--- a/src/components/Cards/Cards.tsx
+++ b/src/components/Cards/Cards.tsx
@@ -38,6 +38,7 @@ export const Card: React.FC<CardProps> = ({
     position="relative"
     display="flex"
     flexDirection="column"
+    height="100%"
   >
     {image && (
       <Box width="inherit">


### PR DESCRIPTION
when cards are added to a grid, if they do not have a similar amount of content they have different heights. Adding height 100% should fix this 