### PR TITLE
fix: wrapping on home page cta button in safari

### DIFF
--- a/src/components/Hero/HomepageHero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero/HomepageHero.tsx
@@ -122,6 +122,7 @@ const HomepageHero = ({
           <Box
             fontSize="clamp(0.6rem, calc(0.8rem + 0.37vw), 1.56rem)"
             flexGrow={1}
+            whiteSpace="normal"
           >
             {callToAction}
           </Box>


### PR DESCRIPTION
The CTA button wraps in chrome but does not wrap in Safari. Adding a white-space parameter fixes this, and does not impact the wrapping on Chrome.The wrapping is also visible on Firefox
Safari before fix:
<img width="370" alt="Screenshot 2023-08-10 at 12 26 00" src="https://github.com/thelawcentresnetwork/lcn-design-system/assets/76073097/e21af2fb-80d1-4711-9963-c13ae5b70d54">

Safari after fix:
<img width="386" alt="Screenshot 2023-08-10 at 12 25 50" src="https://github.com/thelawcentresnetwork/lcn-design-system/assets/76073097/e6159f3d-ffe5-4e10-abbb-78309d22b4ab">
